### PR TITLE
Adding support for ollama custom model path and huggingface models in ollama model directory

### DIFF
--- a/Ollm_Bridge_v0.6.ps1
+++ b/Ollm_Bridge_v0.6.ps1
@@ -1,129 +1,228 @@
-﻿# Ollm Bridge v 0.6
-# Ollm Bridge aims to create a structure of directories and symlinks to make Ollama models more easily accessible to LMStudio users.
+﻿<#
+.SYNOPSIS
+    Creates symbolic links for Ollama models to enhance LM Studio compatibility.
 
-# Define the directory variables
-$manifest_dir = "$env:USERPROFILE\.ollama\models\manifests\registry.ollama.ai"
-$blob_dir = "$env:USERPROFILE\.ollama\models\blobs"
-$publicModels_dir = "$env:USERPROFILE\publicmodels"
+.DESCRIPTION
+    Ollm Bridge creates symbolic links within model-specific subdirectories inside a top-level
+    'hugging-quants' directory, facilitating the use of Ollama models within LM Studio.
+    It identifies the necessary model files (blobs) by examining manifest files from both
+    'registry.ollama.ai' and 'hf.co'.
 
-# Print the base directories to confirm the variables
-Write-Host ""
-Write-Host "Confirming Directories:"
-Write-Host ""
-Write-Host "Manifest Directory: $manifest_dir"
-Write-Host "Blob Directory: $blob_dir"
-Write-Host "Public Models Directory: $publicModels_dir"
+.NOTES
+    Version: 0.6
+#>
 
+#region Configuration
 
-# Check if the $publicmodels\lmstudio directory already exists, and delete it if so
-if (Test-Path $publicModels_dir\lmstudio) {
-    Write-Host ""
-    Remove-Item -Path $publicModels_dir\lmstudio -Recurse -Force
-    Write-Host "Ollm Bridge Directory Reset."
-}
-
-if (Test-Path $publicModels_dir) {
-    Write-Host ""
-    Write-Host "Public Models Directory Confirmed."
+# Determine the base directory for Ollama models.
+# If the environment variable OLLAMA_MODELS is set, use it.
+# Otherwise, default to the standard Ollama models directory in the user's profile.
+if ($env:OLLAMA_MODELS) {
+    # If the environment variable ends with a backslash, use it as is.
+    # Otherwise, add a trailing backslash.
+    $OllamaBaseDir = if ($env:OLLAMA_MODELS.EndsWith('\')) { $env:OLLAMA_MODELS } else { "$($env:OLLAMA_MODELS)\" }
 } else {
-    New-Item -Type Directory -Path $publicModels_dir
-    Write-Host ""
-    Write-Host "Public Models Directory Created."
+    # Default Ollama models directory.
+    $OllamaBaseDir = "$env:USERPROFILE\.ollama\models\"
 }
 
+# Define the base directories where Ollama stores manifest files.
+# These manifests contain metadata about the models.
+$ManifestBaseDirs = @(
+    (Join-Path -Path $OllamaBaseDir -ChildPath "manifests\registry.ollama.ai"), # Manifests from the default Ollama registry.
+    (Join-Path -Path $OllamaBaseDir -ChildPath "manifests\hf.co")              # Manifests from Hugging Face.
+)
+# Define the directory where Ollama stores the actual model files (blobs).
+$BlobDir = Join-Path -Path $OllamaBaseDir -ChildPath "blobs"
 
-# Explore the manifest directory and record the manifest file locations
-Write-Host ""
-Write-Host "Exploring Manifest Directory:"
-Write-Host ""
-$files = Get-ChildItem -Path $manifest_dir -Recurse -Force | Where-Object {$_.PSIsContainer -eq $false}
-$manifestLocations = @()
+# Define the base directory where the symbolic links will be created.
+# This 'hugging-quants' directory will be created inside the Ollama base directory.
+$HuggingQuantsDir = Join-Path -Path $OllamaBaseDir -ChildPath "hugging-quants"
 
-foreach ($file in $files) {
-    $path = "$($file.DirectoryName)\$($file.Name)"
-    $manifestLocations += $path
+#endregion
+
+#region Helper Functions
+
+# Function to write informational messages to the console in green.
+function Write-Info {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [string]$Message # The message to be displayed.
+    )
+    Write-Host -ForegroundColor Green $Message
+}
+
+# Function to write warning messages to the console in yellow.
+function Write-WarningMessage {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [string]$Message # The warning message to be displayed.
+    )
+    Write-Host -ForegroundColor Yellow "Warning: $Message"
+}
+
+# Function to ensure a directory exists. If it doesn't, it creates it.
+function Ensure-Directory {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path # The path of the directory to ensure.
+    )
+    # Check if the directory exists.
+    if (-not (Test-Path -Path $Path)) {
+        Write-Info "Creating directory: '$Path'"
+        # Create the directory.
+        New-Item -ItemType Directory -Path $Path | Out-Null
+    }
+}
+
+# Function to create a symbolic link.
+function Create-SymbolicLink {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$LinkPath,   # The path where the symbolic link will be created.
+        [Parameter(Mandatory = $true)]
+        [string]$TargetPath  # The path to the original file or directory the link will point to.
+    )
+    # Check if the symbolic link already exists.
+    if (-not (Test-Path -Path $LinkPath)) {
+        Write-Info "Creating symbolic link: '$LinkPath' -> '$TargetPath'"
+        # Create the symbolic link.
+        New-Item -ItemType SymbolicLink -Path $LinkPath -Value $TargetPath | Out-Null
+    } else {
+        Write-Info "Symbolic link already exists: '$LinkPath'"
+    }
+}
+
+# Function to construct the full path to a blob file given its digest.
+function Get-BlobPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Digest # The digest of the blob (e.g., "sha256:abcdef...").
+    )
+    # Remove the "sha256:" prefix and construct the full path.
+    return Join-Path -Path $BlobDir -ChildPath ('sha256-' + ($Digest -replace 'sha256:', ''))
+}
+
+#endregion
+
+#region Script Execution
+
+Write-Host ""
+Write-Host "Ollm Bridge v 0.6"
+Write-Host "-----------------"
+Write-Host ""
+Write-Host "Configuration:"
+Write-Host "  Ollama Base Directory: '$OllamaBaseDir'"
+Write-Host "  Blob Directory: '$BlobDir'"
+Write-Host "  Hugging Quants Directory: '$HuggingQuantsDir'"
+Write-Host "  Manifest Base Directories:"
+$ManifestBaseDirs | ForEach-Object { Write-Host "    - $_" }
+Write-Host ""
+
+# Check if the Ollama base model directory exists.
+if (Test-Path $OllamaBaseDir) {
+    Write-Info "Ollama Base Directory Confirmed."
+} else {
+    Write-Error "Ollama Base Directory '$OllamaBaseDir' not found. Please ensure the OLLAMA_MODELS environment variable is set correctly or that Ollama has been initialized."
+    exit 1
+}
+
+# Ensure the base hugging-quants directory exists.
+Ensure-Directory -Path $HuggingQuantsDir
+
+# Process manifests to create symbolic links.
+Write-Host "Processing Manifests..."
+# Iterate through each manifest base directory.
+foreach ($manifestBaseDir in $ManifestBaseDirs) {
+    Write-Host ""
+    # Check if the manifest base directory exists.
+    if (Test-Path $manifestBaseDir) {
+        # Get all manifest files recursively within the current base directory.
+        $manifestFiles = Get-ChildItem -Path $manifestBaseDir -Recurse -File -Force -ErrorAction SilentlyContinue
+        # Process each manifest file.
+        if ($manifestFiles) {
+            foreach ($manifestFile in $manifestFiles) {
+                try {
+                    # Read the content of the manifest file and convert it from JSON.
+                    $manifestContent = Get-Content -Path $manifestFile.FullName -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+                } catch {
+                    Write-WarningMessage "Error reading or parsing JSON file: '$($manifestFile.FullName)'. Skipping."
+                    continue
+                }
+
+                # Check if the manifest contains the 'config.digest'.
+                if (-not $manifestContent.config.digest) {
+                    Write-WarningMessage "Manifest '$($manifestFile.FullName)' does not contain 'config.digest'. Skipping."
+                    continue
+                }
+                # Get the path to the model's configuration file (blob).
+                $modelConfigPath = Get-BlobPath -Digest $manifestContent.config.digest
+
+                try {
+                    # Read the content of the model config file and convert it from JSON.
+                    $modelConfig = Get-Content -Path $modelConfigPath -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+                } catch {
+                    Write-WarningMessage "Error reading or parsing config file: '$modelConfigPath'. Skipping model."
+                    continue
+                }
+
+                # Find the blob containing the actual model data within the layers.
+                $modelFileBlob = $null
+                foreach ($layer in $manifestContent.layers) {
+                    if ($layer.mediaType -like "*model") {
+                        $modelFileBlob = Get-BlobPath -Digest $layer.digest
+                        break
+                    }
+                }
+
+                # If no model layer is found, skip this manifest.
+                if (-not $modelFileBlob) {
+                    Write-WarningMessage "No 'model' layer found in manifest: '$($manifestFile.FullName)'. Skipping."
+                    continue
+                }
+
+                # Extract model information from the manifest and config.
+                $modelName = Split-Path -Path $manifestFile.DirectoryName -Leaf # Get the model name from the directory name.
+                $modelQuant = $modelConfig.file_type                           # Get the quantization type.
+                $modelExt = $modelConfig.model_format                           # Get the model file extension.
+                $modelTrainedOn = $modelConfig.model_type                       # Get information about the training data.
+
+                Write-Host ""
+                Write-Host "  Model Name: '$modelName'"
+                Write-Host "    Quantization: '$modelQuant'"
+                Write-Host "    Extension: '$modelExt'"
+                Write-Host "    Trained On: '$modelTrainedOn'"
+
+                # Define the path for the model-specific subdirectory within 'hugging-quants'.
+                $modelHuggingQuantsDir = Join-Path -Path $HuggingQuantsDir -ChildPath $modelName
+                # Ensure the model-specific subdirectory exists.
+                Ensure-Directory -Path $modelHuggingQuantsDir
+
+                # Create the symbolic link to the model blob file.
+                $linkPath = Join-Path -Path $modelHuggingQuantsDir -ChildPath "$($modelName)-$($modelTrainedOn)-$($modelQuant).$($modelExt)"
+                Create-SymbolicLink -LinkPath $linkPath -TargetPath $modelFileBlob
+
+            }
+        } else {
+            Write-Host "  No manifest files found in '$manifestBaseDir'."
+        }
+    } else {
+        Write-WarningMessage "Manifest directory not found: '$manifestBaseDir'"
+    }
 }
 
 Write-Host ""
-Write-Host "File Locations:"
+Write-Host "---------------------"
+Write-Host -ForegroundColor Green "Ollm Bridge complete."
+Write-Host "---------------------"
 Write-Host ""
-$manifestLocations | ForEach-Object { Write-Host $_ }
-
-
-# Parse through json files to get model info
-foreach ($manifest in $manifestLocations) {
-    $json = Get-Content -Path $manifest
-    $obj = ConvertFrom-Json -InputObject $json
-
-    # Check if the digest is a child of "config"
-    if ($obj.config.digest) {
-        # Replace "sha256:" with "sha256-" in the config digest
-        $modelConfig = "$blob_dir\$('sha256-' + $($obj.config.digest.Replace('sha256:', '')))"
-    }
-
-    foreach ($layer in $obj.layers) {
-        # If mediaType ends in "model", build $modelfile
-        if ($layer.mediaType -like "*model") {
-            # Replace "sha256:" with "sha256-" in the model digest
-            $modelFile = "$blob_dir\$('sha256-' + $($layer.digest.Replace('sha256:', '')))"
-        }
-           
-        # If mediaType ends in "template", build $modelTemplate
-        if ($layer.mediaType -like "*template") {
-            # Replace "sha256:" with "sha256-" in the template digest
-            $modelTemplate = "$blob_dir\$('sha256-' + $($layer.digest.Replace('sha256:', '')))"
-        }
-           
-        # If mediaType ends in "params", build $modelParams
-        if ($layer.mediaType -like "*params") {
-            # Replace "sha256:" with "sha256-" in the parameter digest
-            $modelParams = "$blob_dir\$('sha256-' + $($layer.digest.Replace('sha256:', '')))"
-        }
-    }
-
-    # Extract variables from $modelConfig
-    $modelConfigObj = ConvertFrom-Json (Get-Content -Path $modelConfig)
-
-    $modelQuant = $modelConfigObj.'file_type'
-    $modelExt = $modelConfigObj.'model_format'
-    $modelTrainedOn = $modelConfigObj.'model_type'
-
-    # Get the parent directory of $manifest
-    $parentDir = Split-Path -Path $manifest -Parent
-
-    # Set the $modelName variable to the name of the directory
-    $modelName = (Get-Item -Path $parentDir).Name
-
-    Write-Host ""
-    Write-Host "Model Name is" $modelName
-    Write-Host "Quant is" $modelQuant
-    Write-Host "Extension is" $modelExt
-    Write-Host "Number of Parameters Trained on is" $modelTrainedOn
-    Write-Host ""
-
-
-    # Check if the directory exists and create it if necessary
-    if (-not (Test-Path -Path $publicModels_dir\lmstudio)) {
-        Write-Host ""
-        Write-Host "Creating lmstudio directory..."
-        New-Item -Type Directory -Path $publicModels_dir\lmstudio
-    }
-
-    # Check if the subdirectory exists and create it if necessary
-    if (-not (Test-Path -Path $publicModels_dir\lmstudio\$modelName)) {
-        Write-Host ""
-        Write-Host "Creating $modelName directory..."
-        New-Item -Type Directory -Path $publicModels_dir\lmstudio\$modelName
-    }
-
-    # Create the symbolic link
-    Write-Host ""
-    Write-Host "Creating symbolic link for $modelFile..."
-    New-Item -ItemType SymbolicLink -Path "$publicModels_dir\lmstudio\$modelName\$($modelName)-$($modelTrainedOn)-$($modelQuant).$($modelExt)" -Value $modelFile
-}
-
+Write-Host -ForegroundColor Yellow "Set LM Studio's Models Directory to:" -NoNewline
+Write-Host -ForegroundColor Cyan " '$($OllamaBaseDir)'"
 Write-Host ""
-Write-Host ""
-Write-Host "*********************"
-Write-Host "Ollm Bridge complete."
-Write-Host "Set the Models Directory in LMStudio to"$publicModels_dir"\lmstudio" 
+
+#endregion

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Ollm Bridge is a simple tool designed to streamline the process of accessing Oll
 ## How do I use it?
 1. Download the desired version of Ollm Bridge from our repository or release page.
 2. Run the executable as an administrator (right-click > Run as administrator) or execute the PowerShell script in PowerShell as an administrator.
-3. After completion, set your LMStudio Models Directory to `%userprofile%\publicmodels`.
+3. After completion, set your LMStudio Models Directory to Your Ollama Models Directory. (e.g. 'C:\Users\USER\.ollama\models')
 
 ## Credits
 * Thanks to [Matt Williams](https://github.com/technovangelist) for [inspiration](https://youtu.be/UfhXbwA5thQ?si=ML8x01C26kNStTJw)


### PR DESCRIPTION
# Better Support for Custom Model Locations and Hugging Face Models

## Related Issues
Closes [#4 ](https://github.com/Les-El/Ollm-Bridge/issues/4)- Incompatibility with Ollama Custom Model Paths and Hugging Face Models

## What's New
This update makes Ollm Bridge work better with models stored in different locations, and adds support for models from Hugging Face, and adds better visual feedback through colorful console prompts, making it easier to work with both custom Ollama directories and Hugging Face models.

## Key Changes
### Custom Ollama Model Paths Support
- Added support for custom Ollama model paths through the `OLLAMA_MODELS` environment variable
- The script now checks for `OLLAMA_MODELS` env var before defaulting to the standard `.ollama/models` directory
- Improved path handling to ensure consistent directory separators

### Hugging Face Integration
- Added support for models pulled from Hugging Face via `ollama run hf.co/username/model_name`
- Included `manifests/hf.co` in the manifest search paths
- Improved manifest processing to handle Hugging Face model structures

## Screenshots: 
![image](https://github.com/user-attachments/assets/a2b88124-96b6-4ffa-812a-c4eaa6804d18)

## Notes for Reviewers
- The script now creates the `hugging-quants` directory within the Ollama models directory
- All paths are now handled relative to the base Ollama models directory

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation has been updated
- [x] All new and existing tests pass
- [x] Changes have been tested with various model configurations 